### PR TITLE
fixed for Django>=1.6

### DIFF
--- a/impersonate/urls.py
+++ b/impersonate/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import patterns, url
 from django.views.generic import RedirectView
 from django.core.urlresolvers import reverse_lazy
 


### PR DESCRIPTION
As of Django 1.6, `django.conf.urls.defaults` does not exist.
